### PR TITLE
#3 Support config file

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Please start k8s before running this test
-func TestMain(m *testing.M) {
+func TestConfFile(t *testing.T) {
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
 	content := `engine.spark.confkey=confvalue
@@ -33,6 +33,28 @@ engine.streaming.port=19003`
 		"--engine-image", "techmlsql/mlsql-engine:3.0-2.1.0",
 		"--engine-jar-path-in-container", "local:///home/deploy/mlsql/libs/streamingpro-mlsql-spark_3.0_2.12-2.1.0.jar",
 		"--conf-file", f.Name(),
+	}
+	os.Args = append([]string{"mlsql-deploy"}, args...)
+	main()
+}
+
+// Please start k8s before running this test
+func TestNonConfFile(t *testing.T) {
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+
+	args := []string{
+		"--verbose",
+		"run",
+		"--kube-config", fmt.Sprintf("%s/.kube/config", os.Getenv("HOME")),
+		"--engine-executor-core-num", "1",
+		"--engine-executor-num", "1",
+		"--engine-executor-memory", "512",
+		"--engine-driver-core-num", "1",
+		"--engine-driver-memory", "512",
+		"--engine-name", "mlsql-engine",
+		"--engine-image", "techmlsql/mlsql-engine:3.0-2.1.0",
+		"--engine-jar-path-in-container", "local:///home/deploy/mlsql/libs/streamingpro-mlsql-spark_3.0_2.12-2.1.0.jar",
 	}
 	os.Args = append([]string{"mlsql-deploy"}, args...)
 	main()

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"mlsql.tech/allwefantasy/deploy/pkg/utils"
+	"os"
+	"testing"
+)
+
+// Please start k8s before running this test
+func TestMain(m *testing.M) {
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	content := `engine.spark.confkey=confvalue
+engine.storage.confkey=confvalue
+engine.streaming.port=19003`
+	f, e := utils.CreateTmpFile(content)
+	if e != nil {
+		logger.Error(e)
+	}
+	defer os.Remove(f.Name())
+
+	args := []string{
+		"--verbose",
+		"run",
+		"--kube-config", fmt.Sprintf("%s/.kube/config", os.Getenv("HOME")),
+		"--engine-executor-core-num", "1",
+		"--engine-executor-num", "1",
+		"--engine-executor-memory", "512",
+		"--engine-driver-core-num", "1",
+		"--engine-driver-memory", "512",
+		"--engine-name", "mlsql-engine",
+		"--engine-image", "techmlsql/mlsql-engine:3.0-2.1.0",
+		"--engine-jar-path-in-container", "local:///home/deploy/mlsql/libs/streamingpro-mlsql-spark_3.0_2.12-2.1.0.jar",
+		"--conf-file", f.Name(),
+	}
+	os.Args = append([]string{"mlsql-deploy"}, args...)
+	main()
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -142,7 +142,7 @@ func run(c *cli.Context) error {
 		if strings.HasPrefix(key, "engine.spark") {
 			return fmt.Sprintf("--conf \\\"%s=%s\\\"", key[7:], value)
 		} else {
-			return ""
+			return " "
 		}
 	}
 	// Filters and converts extra mlsql conf.
@@ -150,16 +150,11 @@ func run(c *cli.Context) error {
 		if strings.HasPrefix(key, "engine.streaming") {
 			return fmt.Sprintf("\\\"-%s\\\" \\\"%s\\\"", key[7:], value)
 		} else {
-			return ""
+			return " "
 		}
 	}
 	// Step3: Deploy MLSQL Engine
-	de := struct {
-		*meta.EngineConfig
-		K8sAddress         string
-		LimitDriverCoreNum int64
-		LimitDriverMemory  int64
-	}{
+	de := meta.DeploymentConfig{
 		EngineConfig: &meta.EngineConfig{
 			Name:               metaConfig.EngineConfig.Name,
 			Image:              metaConfig.EngineConfig.Image,
@@ -261,9 +256,10 @@ func engineFlags() []cli.Flag {
 			Usage: "the access token to protect mlsql engine",
 		},
 		&cli.StringFlag{
-			Name:  "engine-jar-path-in-container",
-			Value: "",
-			Usage: "The path of mlsql engine jar in docker image",
+			Name:     "engine-jar-path-in-container",
+			Value:    "",
+			Usage:    "The path of mlsql engine jar in docker image",
+			Required: true,
 		},
 	}
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/urfave/cli/v2"
@@ -9,6 +11,7 @@ import (
 	"mlsql.tech/allwefantasy/deploy/pkg/tpl"
 	"mlsql.tech/allwefantasy/deploy/pkg/utils"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -50,16 +53,68 @@ func run(c *cli.Context) error {
 		StorageConfig: storageConfig,
 	}
 
-	executor := utils.CreateKubeExecutor(&metaConfig.K8sConfig)
+	// Read config from file
+	var extraConf map[string]string
+	var parseConfErr error
+	if c.IsSet("conf-file") {
+		confFile := c.String("conf-file")
+		extraConf, parseConfErr = utils.ReadConfigFile(confFile)
+		if parseConfErr != nil {
+			logger.Fatalf("Failed to read %s, error %s", confFile, err)
+			return err
+		}
+	}
 
 	tplEvt := func(templateStr string, data interface{}) (*os.File, error) {
+		if c.IsSet("verbose") {
+			jsonObj, _ := json.Marshal(data)
+			logger.Infof("%s\n", string(jsonObj))
+		}
 		f, _ := utils.CreateTmpFile(tpl.EvaluateTemplate(templateStr, data))
 		return f, nil
 	}
 
+	// The function converts each key value to a string,
+	// conversion logic is defined in converter function
+	convertToConfString := func(extraConfMap map[string]string,
+		converter func(key, value string) string) string {
+
+		if extraConfMap == nil {
+			return ""
+		}
+		var buff bytes.Buffer
+		for key, value := range extraConfMap {
+			buff.WriteString(converter(key, value))
+		}
+		return buff.String()
+	}
+
+	// Filters and converts key-value pair to a property of core-site.xml
+	storageConfConverter := func(key, value string) string {
+		var buf bytes.Buffer
+		if strings.HasPrefix(key, "engine.storage") {
+			buf.WriteString("<property>\n")
+			buf.WriteString(fmt.Sprintf("<name>%s</name>\n", key[7:]))
+			buf.WriteString(fmt.Sprintf("<value>%s</value>\n", value))
+			buf.WriteString("</property>")
+		}
+		return buf.String()
+	}
+
+	executor := utils.CreateKubeExecutor(&metaConfig.K8sConfig)
 	// Step1: configure CM, so we can support JuiceFS FileSystem
 	executor.DeleteAny([]string{"configmap", "core-site-xml"})
-	coreSiteTmpFile, _ := tplEvt(tpl.TLPCoreSite, metaConfig.StorageConfig)
+
+	coreSiteTmpFile, _ := tplEvt(tpl.TLPCoreSite,
+		meta.StorageConfig{
+			Name:        metaConfig.StorageConfig.Name,
+			MetaUrl:     metaConfig.StorageConfig.MetaUrl,
+			MountPoint:  metaConfig.StorageConfig.MountPoint,
+			AccessKey:   metaConfig.StorageConfig.AccessKey,
+			SecretKey:   metaConfig.StorageConfig.SecretKey,
+			ExtraConfig: convertToConfString(extraConf, storageConfConverter),
+		},
+	)
 	defer os.Remove(coreSiteTmpFile.Name())
 	_, coreSiteTmpErr := executor.CreateCM([]string{"core-site-xml", "--from-file", "core-site.xml=" + coreSiteTmpFile.Name(), "-o", "json"})
 	if coreSiteTmpErr != nil {
@@ -72,18 +127,32 @@ func run(c *cli.Context) error {
 	defer os.Remove(createRoleTmpFile.Name())
 	_, createRoleErr := executor.CreateDeployment([]string{"-f", createRoleTmpFile.Name(), "-o", "json"})
 	if createRoleErr != nil {
-		error := errors.New(fmt.Sprintf("Fail to apply createRole.yaml \n %s", createRoleErr.Error()))
-		return error
+		return errors.New(fmt.Sprintf("Fail to apply createRole.yaml \n %s", createRoleErr.Error()))
 	}
 
 	bindRoleTmpFile, _ := tplEvt(tpl.TLPRoleBinding, tpl.Empty{})
 	defer os.Remove(bindRoleTmpFile.Name())
 	_, bindRoleErr := executor.CreateDeployment([]string{"-f", bindRoleTmpFile.Name(), "-o", "json"})
 	if bindRoleErr != nil {
-		error := errors.New(fmt.Sprintf("Fail to apply roleBinding.yaml \n %s", bindRoleErr.Error()))
-		return error
+		return errors.New(fmt.Sprintf("Fail to apply roleBinding.yaml \n %s", bindRoleErr.Error()))
 	}
 
+	// Filters and converts extra spark conf
+	sparkConfConverter := func(key, value string) string {
+		if strings.HasPrefix(key, "engine.spark") {
+			return fmt.Sprintf("--conf \\\"%s=%s\\\"", key[7:], value)
+		} else {
+			return ""
+		}
+	}
+	// Filters and converts extra mlsql conf.
+	mlsqlConfConverter := func(key, value string) string {
+		if strings.HasPrefix(key, "engine.streaming") {
+			return fmt.Sprintf("\\\"-%s\\\" \\\"%s\\\"", key[7:], value)
+		} else {
+			return ""
+		}
+	}
 	// Step3: Deploy MLSQL Engine
 	de := struct {
 		*meta.EngineConfig
@@ -91,7 +160,19 @@ func run(c *cli.Context) error {
 		LimitDriverCoreNum int64
 		LimitDriverMemory  int64
 	}{
-		EngineConfig:       &metaConfig.EngineConfig,
+		EngineConfig: &meta.EngineConfig{
+			Name:               metaConfig.EngineConfig.Name,
+			Image:              metaConfig.EngineConfig.Image,
+			ExecutorCoreNum:    metaConfig.EngineConfig.ExecutorCoreNum,
+			ExecutorNum:        metaConfig.EngineConfig.ExecutorNum,
+			ExecutorMemory:     metaConfig.EngineConfig.ExecutorMemory,
+			DriverCoreNum:      metaConfig.EngineConfig.DriverCoreNum,
+			DriverMemory:       metaConfig.EngineConfig.DriverMemory,
+			AccessToken:        metaConfig.EngineConfig.AccessToken,
+			JarPathInContainer: metaConfig.EngineConfig.JarPathInContainer,
+			ExtraSparkConfig:   convertToConfString(extraConf, sparkConfConverter),
+			ExtraMLSQLConfig:   convertToConfString(extraConf, mlsqlConfConverter),
+		},
 		K8sAddress:         executor.GetK8sAddress(),
 		LimitDriverCoreNum: metaConfig.EngineConfig.DriverCoreNum * 2,
 		LimitDriverMemory:  metaConfig.EngineConfig.DriverMemory * 2,
@@ -99,18 +180,18 @@ func run(c *cli.Context) error {
 
 	deployTmpFile, _ := tplEvt(tpl.TLPDeployment, de)
 	defer os.Remove(deployTmpFile.Name())
+
 	_, deployErr := executor.CreateDeployment([]string{"-f", deployTmpFile.Name(), "-o", "json"})
 	if deployErr != nil {
-		error := errors.New(fmt.Sprintf("Fail to apply deployment.yaml \n %s", deployErr.Error()))
-		return error
+		return errors.New(fmt.Sprintf("Fail to apply deployment.yaml \n %s", deployErr.Error()))
 	}
 
 	// Step4: Expose MLSQL Engine service
 	_, serviceErr := executor.CreateExpose([]string{"deployment", metaConfig.EngineConfig.Name, "--port", "9003",
 		"--target-port", "9003", "--type", "NodePort"})
 	if serviceErr != nil {
-		error := errors.New(fmt.Sprintf("Fail to expose service \n %s", serviceErr.Error()))
-		return error
+		return errors.New(fmt.Sprintf("Fail to expose service \n %s", serviceErr.Error()))
+
 	}
 
 	// step5: Create Ingress
@@ -118,8 +199,7 @@ func run(c *cli.Context) error {
 	defer os.Remove(ingressTmpFile.Name())
 	_, ingressErr := executor.CreateDeployment([]string{"-f", ingressTmpFile.Name(), "-o", "json"})
 	if ingressErr != nil {
-		error := errors.New(fmt.Sprintf("Fail to create ingress for %s: %s", de.Name, ingressErr.Error()))
-		return error
+		return errors.New(fmt.Sprintf("Fail to create ingress for %s: %s", de.Name, ingressErr.Error()))
 	}
 
 	// Step6: Wait MLSQL Engine proxy service IP ready
@@ -234,5 +314,11 @@ func runFlags() *cli.Command {
 	}
 	cmd.Flags = append(cmd.Flags, engineFlags()...)
 	cmd.Flags = append(cmd.Flags, storageFlags()...)
+
+	cmd.Flags = append(cmd.Flags, &cli.StringFlag{
+		Name:     "conf-file",
+		Required: false,
+		Usage:    "config file full path",
+	})
 	return cmd
 }

--- a/pkg/meta/config.go
+++ b/pkg/meta/config.go
@@ -22,13 +22,15 @@ type EngineConfig struct {
 
 	AccessToken        string
 	JarPathInContainer string
-	SparkConfig        map[string]string
+	ExtraSparkConfig   string
+	ExtraMLSQLConfig   string
 }
 
 type StorageConfig struct {
-	Name       string
-	MetaUrl    string
-	MountPoint string
-	AccessKey  string
-	SecretKey  string
+	Name        string
+	MetaUrl     string
+	MountPoint  string
+	AccessKey   string
+	SecretKey   string
+	ExtraConfig string
 }

--- a/pkg/meta/config.go
+++ b/pkg/meta/config.go
@@ -34,3 +34,10 @@ type StorageConfig struct {
 	SecretKey   string
 	ExtraConfig string
 }
+
+type DeploymentConfig struct {
+	*EngineConfig
+	K8sAddress         string
+	LimitDriverCoreNum int64
+	LimitDriverMemory  int64
+}

--- a/pkg/tpl/templates/core-site.xml
+++ b/pkg/tpl/templates/core-site.xml
@@ -26,4 +26,5 @@
         <name>juicefs.access-log</name>
         <value>/tmp/juicefs.access.log</value>
     </property>
+    {{.ExtraConfig}}
 </configuration>

--- a/pkg/tpl/templates/createRole.yaml
+++ b/pkg/tpl/templates/createRole.yaml
@@ -8,6 +8,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - pods
   - pods/status
   - pods/log

--- a/pkg/tpl/templates/deployment.yaml
+++ b/pkg/tpl/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
             --conf "\"spark.executor.extraJavaOptions=-XX:+UnlockExperimentalVMOptions -XX:+UseZGC -XX:+UseContainerSupport  -Dio.netty.tryReflectionSetAccessible=true\""
             --conf "\"spark.driver.extraJavaOptions=-XX:+UnlockExperimentalVMOptions -XX:+UseZGC -XX:+UseContainerSupport  -Dio.netty.tryReflectionSetAccessible=true\""
             --conf "\"spark.executor.extraLibraryPath=local:///home/deploy/mlsql/libs/juicefs-hadoop-0.15.2-linux-amd64.jar:local:///home/deploy/mlsql/libs/ansj_seg-5.1.6.jar:local:///home/deploy/mlsql/libs/nlp-lang-1.7.8.jar\""
-            {{.EngineConfig.ExtraSparkConfig}}
+            {{.EngineConfig.ExtraSparkConfig -}}
             {{.EngineConfig.JarPathInContainer}}
             -streaming.name {{.EngineConfig.Name}}
             -streaming.rest true
@@ -63,7 +63,7 @@ spec:
             -streaming.spark.service true
             -streaming.job.cancel true
             -streaming.driver.port 9003
-            {{.EngineConfig.ExtraMLSQLConfig}}
+            {{- .EngineConfig.ExtraMLSQLConfig}}
             " | bash
         command:
           - /bin/sh

--- a/pkg/tpl/templates/deployment.yaml
+++ b/pkg/tpl/templates/deployment.yaml
@@ -25,7 +25,8 @@ spec:
       - name: {{.EngineConfig.Name}}
         args:
           - >-
-            echo "/work/spark-3.1.1-bin-hadoop3.2/bin/spark-submit --master k8s://https://{{.K8sAddress}}
+            echo "/work/spark-3.1.1-bin-hadoop3.2/bin/spark-submit
+            --master k8s://https://{{.K8sAddress}}
             --deploy-mode client
             --driver-memory {{.EngineConfig.DriverMemory}}m
             --driver-cores  {{.EngineConfig.DriverCoreNum}}
@@ -52,6 +53,7 @@ spec:
             --conf "\"spark.executor.extraJavaOptions=-XX:+UnlockExperimentalVMOptions -XX:+UseZGC -XX:+UseContainerSupport  -Dio.netty.tryReflectionSetAccessible=true\""
             --conf "\"spark.driver.extraJavaOptions=-XX:+UnlockExperimentalVMOptions -XX:+UseZGC -XX:+UseContainerSupport  -Dio.netty.tryReflectionSetAccessible=true\""
             --conf "\"spark.executor.extraLibraryPath=local:///home/deploy/mlsql/libs/juicefs-hadoop-0.15.2-linux-amd64.jar:local:///home/deploy/mlsql/libs/ansj_seg-5.1.6.jar:local:///home/deploy/mlsql/libs/nlp-lang-1.7.8.jar\""
+            {{.EngineConfig.ExtraSparkConfig}}
             {{.EngineConfig.JarPathInContainer}}
             -streaming.name {{.EngineConfig.Name}}
             -streaming.rest true
@@ -60,7 +62,9 @@ spec:
             -streaming.enableHiveSupport true
             -streaming.spark.service true
             -streaming.job.cancel true
-            -streaming.driver.port 9003" | bash
+            -streaming.driver.port 9003
+            {{.EngineConfig.ExtraMLSQLConfig}}
+            " | bash
         command:
           - /bin/sh
           - '-c'

--- a/pkg/tpl/tpl_test.go
+++ b/pkg/tpl/tpl_test.go
@@ -1,0 +1,31 @@
+package tpl
+
+import (
+	"mlsql.tech/allwefantasy/deploy/pkg/meta"
+	"strings"
+	"testing"
+)
+
+func TestEvaluateDeploymentTemplate(t *testing.T) {
+	de := meta.DeploymentConfig{
+		EngineConfig: &meta.EngineConfig{
+			Name:               "TestEvaluateDeploymentTemplate",
+			Image:              "techmlsql/mlsql-engine:3.0-2.1.0",
+			ExecutorCoreNum:    1,
+			ExecutorNum:        1,
+			ExecutorMemory:     512,
+			DriverCoreNum:      1,
+			DriverMemory:       512,
+			AccessToken:        "mlsql",
+			JarPathInContainer: "local:///home/deploy/mlsql/libs/streamingpro-mlsql-spark_3.0_2.12-2.1.0.jar",
+		},
+		K8sAddress:         "https://localhost:8443",
+		LimitDriverCoreNum: 1,
+		LimitDriverMemory:  1,
+	}
+	tplStr := EvaluateTemplate(TLPDeployment, de)
+
+	if !strings.Contains(tplStr, "local:///home/deploy/mlsql/libs/streamingpro-mlsql-spark_3.0_2.12-2.1.0.jar") {
+		t.Errorf("Evaluated container args is invalid\n%s", tplStr)
+	}
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"os"
+	"testing"
+)
+
+func TestReadConfigFile(t *testing.T) {
+	content := `engine.spark.confkey=confvalue
+engine.storage.confkey=confvalue`
+	f, e := CreateTmpFile(content)
+	if e != nil {
+		t.Error(e)
+	}
+	defer os.Remove(f.Name())
+
+	conf, err := ReadConfigFile(f.Name())
+
+	if err != nil {
+		t.Error(e)
+	}
+	if conf["engine.spark.confkey"] != "confvalue" {
+		t.Error("Config file should contain engine.spark.confkey=confvalue")
+	}
+
+	if conf["engine.storage.confkey"] != "confvalue" {
+		t.Error("Config file should contain engine.storage.confkey=confvalue")
+	}
+
+}


### PR DESCRIPTION
## What changes are proposed?
To support arbitrary configurations from a file, add a new flag --conf-file, this flag is optional.

### Usage
Create a configuration file. Please note: 
 - Each config is in key=value format.
 - Each config should start with engine, otherwise it'd be silently ignored.
 - engine.spark.* config goes to spark-submit 
 - engine.storage.* config goes to core-site.xml

example:  ~/.engine.config. 
```shell
engine.spark.kubernetes.container.image.pullPolicy=Always
engine.storage.key=value
```

Running mlsql-deploy command 
```shell
./mlsql-deploy run \
--kube-config ~/.kube/config \
--engine-name mlsql-k8s --engine-image techmlsql/mlsql-engine:3.0-2.1.0 \
--engine-executor-core-num 2 \
--engine-executor-num 1 \
--engine-executor-memory 2048 \
--engine-driver-core-num 2 \
--engine-driver-memory 2048 \
--engine-access-token mlsql \
--engine-jar-path-in-container local:///home/deploy/mlsql/libs/streamingpro-mlsql-spark_3.0_2.12-2.1.0.jar \
--storage-name jfs \
--storage-meta-url redis://127.0.0.1:6379/1 \
--conf-file ~/.engine.config
```


## How was this PR tested?
- [x] unit-test main_test.go and utils_test.go are passed
- [x] manually tested 

