### PR TITLE
fix some minor code

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ juicefs format \
   --engine-jar-path-in-container local:///home/deploy/mlsql/libs/streamingpro-mlsql-spark_3.0_2.12-2.1.0.jar   \
   --storage-name  jfs \
   --storage-meta-url redis://127.0.0.1:6379/1 \
-  --conf-file /home/hadoop/.engine.config
+  --engine-config /home/hadoop/.engine.config
 ```
 
 /home/hadoop/.engine.config


### PR DESCRIPTION
1. rename `conf-file` to `engine-config`,
2. `logger.Fatalf` will exit the process so there no need to use `return`
3. When engine-config file is set , load fail should exit the process otherwise the user may be not knowing that weather the config file take effect.
4. using trimPrefix instead of string slice operation which is more clear.
5. engine-config file support empty line and comment line e.g. line starts with `# `